### PR TITLE
use mp4 instead of gif

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
       const html = htm.bind(React.createElement)
 
       const getGiphyUrl = gifLink =>
-        `https://i.giphy.com/${gifLink.split('/').pop().split('-').pop()}.gif`
+        `https://i.giphy.com/${gifLink.split('/').pop().split('-').pop()}.mp4`
 
       function App() {
         const [search, setSearch] = React.useState('')
@@ -165,7 +165,10 @@
                         )
                       }}
                     >
-                      <img
+                      <video
+                        autoPlay                    
+                        loop
+                        muted
                         style=${{display: 'block', width: '100%'}}
                         alt=${key}
                         src=${getGiphyUrl(gif)}


### PR DESCRIPTION
Total gif size is about 130MB.

If you replace it with mp4, it will be about 15MB. 

P.S. Would love to see your version of this GIF 😁  
https://i.giphy.com/media/1jnyRP4DorCh2/giphy.gif